### PR TITLE
Move dhcp6c-ifupdown symlink to if-post-down.d

### DIFF
--- a/debian/wide-dhcpv6-client.links
+++ b/debian/wide-dhcpv6-client.links
@@ -1,2 +1,2 @@
 etc/wide-dhcpv6/dhcp6c-ifupdown /etc/network/if-up.d/wide-dhcpv6-client
-etc/wide-dhcpv6/dhcp6c-ifupdown /etc/network/if-down.d/wide-dhcpv6-client
+etc/wide-dhcpv6/dhcp6c-ifupdown /etc/network/if-post-down.d/wide-dhcpv6-client


### PR DESCRIPTION
When managing connections with NetworkManager, interface `up` and `down` events are dispatched to ifupdown `if-up` and `if-post-down` corespondingly.
Moving `dhcp6c-ifupdown` from `if-down.d` to `if-post-down.d` will make this script compatible with NetworkManager without breaking existing ifupdown managed connections.